### PR TITLE
Hide Windows console when running process

### DIFF
--- a/src-tauri/src/lichess.rs
+++ b/src-tauri/src/lichess.rs
@@ -253,6 +253,7 @@ pub fn work(app_handle: &AppHandle) -> Result<(), Box<dyn Error>> {
         process.stdin(Stdio::piped()).stdout(Stdio::piped());
 
         // Hide the console window on Windows
+        #[cfg(windows)]
         if cfg!(windows) {
             use std::os::windows::process::CommandExt;
 

--- a/src-tauri/src/lichess.rs
+++ b/src-tauri/src/lichess.rs
@@ -249,10 +249,18 @@ pub fn work(app_handle: &AppHandle) -> Result<(), Box<dyn Error>> {
         }
 
         // Step 2) Send the FEN to the engine
-        let mut engine = Command::new(binary_filepath.as_ref().expect("missing binary_filepath"))
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn();
+        let mut process = Command::new(binary_filepath.as_ref().expect("missing binary_filepath"));
+        process.stdin(Stdio::piped()).stdout(Stdio::piped());
+
+        // Hide the console window on Windows
+        if cfg!(windows) {
+            use std::os::windows::process::CommandExt;
+
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            process.creation_flags(CREATE_NO_WINDOW);
+        }
+
+        let mut engine = process.spawn();
 
         match engine {
             Ok(_) => {}


### PR DESCRIPTION
Windows would temporarily open a Command Prompt window each time a command was run.