### PR TITLE
Fix infinite analysis and obey the searchtime slider

### DIFF
--- a/src-tauri/src/lichess.rs
+++ b/src-tauri/src/lichess.rs
@@ -31,6 +31,7 @@ struct Work {
     threads: u32,
     hash: u32,
     infinite: bool,
+    movetime: u32,
     multi_pv: u32,
     variant: String,
     initial_fen: String,
@@ -309,15 +310,11 @@ pub fn work(app_handle: &AppHandle) -> Result<(), Box<dyn Error>> {
             analysis_request.work.moves.join(" ")
         )?;
 
-        if analysis_request.work.infinite {
-            writeln!(engine_stdin, "go infinite")?;
-        } else {
-            writeln!(
-                engine_stdin,
-                "go depth {}\n",
-                analysis_request.engine.default_depth
-            )?;
-        }
+        writeln!(
+            engine_stdin,
+            "go movetime {}\n",
+            analysis_request.work.movetime
+        )?;
 
         engine_stdin.flush()?;
 

--- a/src/stores/analysis.ts
+++ b/src/stores/analysis.ts
@@ -64,6 +64,7 @@ interface LichessAnalysisRequest {
   work: {
     hash: number
     infinite: boolean
+    movetime: number
     initialFen: string
     moves: string[]
     multiPv: number


### PR DESCRIPTION
See https://github.com/lichess-org/lila/pull/14021 and https://github.com/lichess-org/lila/commit/b386ad530bc5b3db92e75383c193338de34127a0. 

`work.infinite` is always true rn and is therefore functionally useless. `work.movetime` does the heavy lifting.